### PR TITLE
Moved CODE_OF_CONDUCT from the website github repo

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,101 @@
+As a community we welcome everyone, and encourage a friendly and positive environment.
+
+This code of conduct outlines our expectations for participants within the
+community, as well as steps to reporting unacceptable behavior. We are committed
+to providing a welcoming and inspiring community for all and expect our code of
+conduct to be honored. Anyone who violates this code of conduct may be banned
+from the community.
+
+Our open source community strives to:
+
+- **Be friendly and patient.**
+
+- **Be welcoming**: We strive to be a community that welcomes and supports
+  people of all backgrounds and identities. This includes, but is not limited to
+  members of any race, ethnicity, culture, national origin, colour, immigration
+  status, social and economic class, educational level, sex, sexual orientation,
+  gender identity and expression, age, size, family status, political belief,
+  religion, and mental and physical ability.
+
+- **Be considerate**: Your work will be used by other people, and you in turn
+  will depend on the work of others. Any decision you take will affect users and
+  colleagues, and you should take those consequences into account when making
+  decisions. Remember that we're a world-wide community, so you might not be
+  communicating in someone else's primary language.
+
+- **Be respectful**: Not all of us will agree all the time, but disagreement is
+  no excuse for poor behavior and poor manners. We might all experience some
+  frustration now and then, but we cannot allow that frustration to turn into a
+  personal attack. It’s important to remember that a community where people feel
+  uncomfortable or threatened is not a productive one.
+
+- **Be careful in the words that we choose**: We are a community of
+  professionals, and we conduct ourselves professionally. Be kind to others. Do
+  not insult or put down other participants. Harassment and other exclusionary
+  behavior aren't acceptable. This includes, but is not limited to: Violent
+  threats or language directed against another person, Discriminatory jokes and
+  language, Posting sexually explicit or violent material, Posting (or
+  threatening to post) other people’s personally identifying information
+  (“doxing”), Personal insults, especially those using racist or sexist terms,
+  Unwelcome sexual attention, Advocating for, or encouraging, any of the above
+  behavior, Repeated harassment of others. In general, if someone asks you to
+  stop, then stop.
+
+- **Try to understand why we disagree**: Disagreements, both social and
+  technical, happen all the time. It is important that we resolve disagreements
+  and differing views constructively. Remember that we’re different. Diversity
+  contributes to the strength of our community, which is composed of people from
+  a wide range of backgrounds. Different people have different perspectives on
+  issues. Being unable to understand why someone holds a viewpoint doesn’t mean
+  that they’re wrong. Don’t forget that it is human to err and blaming each
+  other doesn’t get us anywhere. Instead, focus on helping to resolve issues and
+  learning from mistakes.
+
+### Diversity Statement
+
+We encourage everyone to participate and are committed to building a community
+for all. Although we will fail at times, we seek to treat everyone both as
+fairly and equally as possible. Whenever a participant has made a mistake, we
+expect them to take responsibility for it. If someone has been harmed or
+offended, it is our responsibility to listen carefully and respectfully, and do
+our best to right the wrong.
+
+Although this list cannot be exhaustive, we explicitly honor diversity in age,
+gender, gender identity or expression, culture, ethnicity, language, national
+origin, political beliefs, profession, race, religion, sexual orientation,
+socioeconomic status, and technical ability. We will not tolerate discrimination
+based on any of the protected characteristics above, including participants with
+disabilities.
+
+### Reporting Issues
+
+If you experience or witness unacceptable behavior, or have any other concerns,
+please report it by contacting the organisers - Bérénice, Malvika and Yo.
+(team@openlifesci.org).
+
+To report an issue involving one of the members, please email one of the members individually
+(berenice@openlifesci.org, malvika@openlifesci.org, yo@openlifesci.org).
+
+All reports will be handled with discretion. In your report please include:
+
+- Your contact information.
+
+- Names (real, nicknames, or pseudonyms) of any individuals involved. If there
+  are additional witnesses, please include them as well. Your account of what
+  occurred, and if you believe the incident is ongoing. If there is a publicly
+  available record (e.g. a mailing list archive or a public IRC logger), please
+  include a link.
+
+- Any additional information that may be helpful.
+
+After filing a report, a representative will contact you personally, review the
+incident, follow up with any additional questions, and make a decision as to how
+to respond. If the person who is harassing you is part of the response team,
+they will recuse themselves from handling your incident. If the complaint
+originates from a member of the response team, it will be handled by a different
+member of the response team. We will respect confidentiality requests for the
+purpose of protecting victims of abuse.
+
+### Attribution & Acknowledgements
+
+This code of conduct is based on the Open Code of Conduct from the TODOGroup.


### PR DESCRIPTION
Fixed issue 414 https://github.com/open-life-science/open-life-science.github.io/issues/414 of open life science website github repository.

Move code of conduct to policies repository